### PR TITLE
Fixed mantine colors when exporting

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -88,6 +88,11 @@
 
   :root {
     --fc-neutral-bg-color: rgb(243, 244, 246);
+    --burger-color: rgb(0, 0, 0);
+
+    /* mantine colors aren't available after running export for some reason */
+    --mantine-color-blue-light: rgba(34, 139, 230, .15);
+    --mantine-color-blue-light-color: #74c0fc;
   }
 
   .dark {
@@ -95,7 +100,6 @@
     --fc-neutral-bg-color: rgb(31 41 55);
     --fc-list-event-hover-bg-color: rgb(107 114 128);
 
-    /* TODO */
     --fc-button-bg-color: rgb(12, 74, 110);
     --fc-button-hover-bg-color: rgb(7, 89, 133);
     --fc-button-hover-border-color: rgb(7, 89, 133);
@@ -105,6 +109,9 @@
 
     --fc-neutral-bg-color: rgb(75, 85, 99);
     --fc-neutral-text-color: rgb(255 255 255 / 80%);
+
+    /* mantine colors aren't available after running export for some reason */
+    --burger-color: rgb(255, 255, 255);
   }
 
   .dark .fc-theme-standard .fc-list-day-cushion {

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -22,7 +22,7 @@ export default function Navbar({sidebarOpened, toggleSidebar} : {sidebarOpened: 
             <Menu.Item key={item.link}>
                 <Link
                     href={item.link}
-                    className="leading-none py-2 px-3 font-light hover:bg-gray-100 dark:hover:bg-gray-500 rounded dark:text-white flex flex-row items-center"
+                    className="leading-none py-2 px-2 font-light hover:bg-gray-100 dark:hover:bg-gray-500 rounded dark:text-white flex flex-row items-center"
                 >
                     <div className="w-5 h-5 mr-2">
                         {Icon}
@@ -44,14 +44,13 @@ export default function Navbar({sidebarOpened, toggleSidebar} : {sidebarOpened: 
                     <Menu.Target>
                         <Link
                             href={link.link}
-                            className="block leading-none py-2 px-3 font-light hover:bg-gray-100 dark:hover:bg-gray-500 rounded"
+                            className="leading-none py-2 px-3 font-light hover:bg-gray-100 dark:hover:bg-gray-500 rounded flex flex-row items-center"
                         >
-                            <Center>
                                 <span className="mr-1">{link.label}</span>
                                 <div className="mt-1 text-gray-600 dark:text-white">
                                     <ChevronDown />
                                 </div>
-                            </Center>
+
                         </Link>
                     </Menu.Target>
                 <Menu.Dropdown className="dark:bg-gray-700 dark:border-slate-800">{menuItems}</Menu.Dropdown>


### PR DESCRIPTION
## Problem 
Mantine colors are set via varibales which werent always available after exporting for some unknown reason

## Solution
Added used mantine colors manually to `globals.css`. 

## Future Updates
This website uses only few mantine components. They could be replaced with custom components to avoid issues like this and decrease bundle size.